### PR TITLE
Fix README code block closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@
 ```bash
 sudo apt-get update
 sudo apt-get install -y ffmpeg inotify-tools
+```


### PR DESCRIPTION
## Summary
- close the shell command block in README

## Testing
- `git status --short`
