### PR TITLE
feat: 720p対応・縦動画自動検出・全体リファクタリング

### DIFF
--- a/watch-and-convert-mp4.sh
+++ b/watch-and-convert-mp4.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 #
 # input/ に新たに .mp4 ファイルが置かれたら、
-# 10MB未満を目標に FullHD 60fps にエンコードしたファイルを output/ に書き出し、
+# 10MB未満を目標に 720p 60fps にエンコードしたファイルを output/ に書き出し、
 # 処理が終わったら元ファイル (input/*.mp4) を削除します。
+#
+# 縦動画 (高さ > 幅) が入力された場合は、自動的に 720x1280 に変換します。
 #
 # 依存:
 #   - inotifywait (inotify-tools パッケージ)
@@ -10,9 +12,11 @@
 #
 # 使い方:
 #   1) input/ と output/ ディレクトリがあることを確認
-#   2) chmod +x watch_and_convert.sh
-#   3) ./watch_and_convert.sh
+#   2) chmod +x watch-and-convert-mp4.sh
+#   3) ./watch-and-convert-mp4.sh
 #
+
+set -euo pipefail
 
 # ------ ここからユーザ設定 ------
 TARGET_MAX_SIZE_MB=10      # 上限サイズ (この値未満を目標)
@@ -22,7 +26,8 @@ PRESET="medium"            # x264のプリセット
 AUDIO_BITRATE=128          # kbps
 MIN_AUDIO_BITRATE=24       # kbps (ターゲットが小さい場合に自動調整)
 MIN_VIDEO_BITRATE=30       # kbps (極端な圧縮時の下限)
-SCALE="1920:1080"          # FullHD
+TARGET_SHORT=720           # 短辺のターゲット解像度 (720p)
+TARGET_LONG=1280           # 長辺のターゲット解像度 (720p)
 FRAMERATE="60"
 # ------ ここまでユーザ設定 ------
 
@@ -30,39 +35,75 @@ INPUT_DIR="input"
 OUTPUT_DIR="output"
 
 # 事前にフォルダが存在するか確認
-if [ ! -d "${INPUT_DIR}" ]; then
-  echo "Error: '${INPUT_DIR}' フォルダが存在しません。"
+if [[ ! -d "${INPUT_DIR}" ]]; then
+  echo "Error: '${INPUT_DIR}' フォルダが存在しません。" >&2
   exit 1
 fi
-if [ ! -d "${OUTPUT_DIR}" ]; then
-  echo "Error: '${OUTPUT_DIR}' フォルダが存在しません。"
+if [[ ! -d "${OUTPUT_DIR}" ]]; then
+  echo "Error: '${OUTPUT_DIR}' フォルダが存在しません。" >&2
   exit 1
 fi
+
+# ---- 入力動画の向きを判定し、適切なscaleフィルターを返す関数 ----
+get_scale_filter () {
+  local in_filepath="$1"
+
+  local width height
+  width="$(ffprobe -v error -select_streams v:0 \
+           -show_entries stream=width -of csv=p=0 "${in_filepath}")"
+  height="$(ffprobe -v error -select_streams v:0 \
+            -show_entries stream=height -of csv=p=0 "${in_filepath}")"
+
+  if [[ -z "${width}" || -z "${height}" ]]; then
+    echo "scale=${TARGET_LONG}:${TARGET_SHORT}"
+    return
+  fi
+
+  if (( height > width )); then
+    # 縦動画: 幅=720, 高さ=1280
+    echo "scale=${TARGET_SHORT}:${TARGET_LONG}"
+  else
+    # 横動画 (正方形含む): 幅=1280, 高さ=720
+    echo "scale=${TARGET_LONG}:${TARGET_SHORT}"
+  fi
+}
 
 # ---- 2passエンコード + ファイルサイズ再調整を行う関数 ----
 encode_to_target_size () {
   local in_filepath="$1"
   local out_filepath="$2"
 
-  # 拡張子抜きのベースファイル名を取得 (passlog名に使う)
+  # 一時ディレクトリを作成してパスログを安全に管理
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  # 関数終了時に一時ディレクトリを確実に削除
+  trap 'rm -rf "${tmpdir}"' RETURN
+
   local basename_noext
   basename_noext="$(basename "${in_filepath}" .mp4)"
+  local passlog="${tmpdir}/${basename_noext}_2pass"
 
   local target_max_bytes=$(( TARGET_MAX_SIZE_MB * 1024 * 1024 ))
   local target_size_bytes=$(( target_max_bytes - SIZE_MARGIN_KB * 1024 ))
-  if [ "${target_size_bytes}" -le 0 ]; then
-    echo "  --> エラー: TARGET_MAX_SIZE_MB / SIZE_MARGIN_KB の設定値が不正です。"
+  if (( target_size_bytes <= 0 )); then
+    echo "  --> エラー: TARGET_MAX_SIZE_MB / SIZE_MARGIN_KB の設定値が不正です。" >&2
     return 1
   fi
 
+  # 動画の長さを取得
   local duration
   duration="$(ffprobe -v error -select_streams v:0 -show_entries format=duration \
              -of csv=p=0 "${in_filepath}")"
 
-  if [ -z "${duration}" ]; then
-    echo "  --> エラー: 動画の長さを取得できませんでした。"
+  if [[ -z "${duration}" ]]; then
+    echo "  --> エラー: 動画の長さを取得できませんでした。" >&2
     return 1
   fi
+
+  # 入力動画の向きに応じたscaleフィルターを決定
+  local scale_filter
+  scale_filter="$(get_scale_filter "${in_filepath}")"
+  echo "  --> scaleフィルター: ${scale_filter}"
 
   # 目標サイズから平均総ビットレート(kbps)を算出し、音声を含めて動的に配分
   local target_total_kbps
@@ -70,7 +111,7 @@ encode_to_target_size () {
     'BEGIN { printf "%.0f", (size_bits / dur) / 1000 }')
 
   local dynamic_audio_bitrate="${AUDIO_BITRATE}"
-  if [ "${target_total_kbps}" -le $((AUDIO_BITRATE + MIN_VIDEO_BITRATE)) ]; then
+  if (( target_total_kbps <= AUDIO_BITRATE + MIN_VIDEO_BITRATE )); then
     dynamic_audio_bitrate=$(
       awk -v total="${target_total_kbps}" -v min_aud="${MIN_AUDIO_BITRATE}" \
         'BEGIN {
@@ -101,9 +142,9 @@ encode_to_target_size () {
       printf "%d", cand;
     }')
 
-  local max_video_bitrate=$((video_bitrate_initial * 4))
-  if [ "${max_video_bitrate}" -lt $((video_bitrate_initial + 200)) ]; then
-    max_video_bitrate=$((video_bitrate_initial + 200))
+  local max_video_bitrate=$(( video_bitrate_initial * 4 ))
+  if (( max_video_bitrate < video_bitrate_initial + 200 )); then
+    max_video_bitrate=$(( video_bitrate_initial + 200 ))
   fi
 
   local max_loop
@@ -123,37 +164,35 @@ encode_to_target_size () {
   local best_over_bitrate="${video_bitrate_initial}"
 
   echo "  --> 動画長さ: ${duration}s"
-  echo "  --> 上限サイズ: ${TARGET_MAX_SIZE_MB} MB (探索目標: $((target_size_bytes/1024/1024)) MB台)"
+  echo "  --> 上限サイズ: ${TARGET_MAX_SIZE_MB} MB (探索目標: $((target_size_bytes / 1024 / 1024)) MB台)"
   echo "  --> 目標総ビットレート: ${target_total_kbps} kbps"
   echo "  --> 音声ビットレート: ${dynamic_audio_bitrate} kbps"
   echo "  --> 初期ビットレート推定: ${video_bitrate_initial} kbps"
 
-  # 2passエンコード用の内部関数 (1回の試行)
+  # 2passエンコード (1回の試行)
   do_2pass () {
     local bitrate_kbps="$1"
-    local passlog="${basename_noext}_2pass.log"
 
     # 1pass
     ffmpeg -y -i "${in_filepath}" \
       -c:v libx264 -preset "${PRESET}" -b:v "${bitrate_kbps}k" \
       -pass 1 -passlogfile "${passlog}" \
-      -pix_fmt yuv420p -r "${FRAMERATE}" -s "${SCALE}" \
+      -vf "${scale_filter}" \
+      -pix_fmt yuv420p -r "${FRAMERATE}" \
       -an -f mp4 /dev/null 2>/dev/null
 
     # 2pass
     ffmpeg -y -i "${in_filepath}" \
       -c:v libx264 -preset "${PRESET}" -b:v "${bitrate_kbps}k" \
       -pass 2 -passlogfile "${passlog}" \
-      -pix_fmt yuv420p -r "${FRAMERATE}" -s "${SCALE}" \
+      -vf "${scale_filter}" \
+      -pix_fmt yuv420p -r "${FRAMERATE}" \
       -c:a aac -b:a "${dynamic_audio_bitrate}k" \
       "${out_filepath}" 2>/dev/null
-
-    rm -f "${passlog}"*
   }
 
   # ビットレート調整の二分探索ループ
-  while [ "${current_loop}" -le "${max_loop}" ]
-  do
+  while (( current_loop <= max_loop )); do
     local cur_video_bitrate
     cur_video_bitrate=$(
       awk -v min="${min_video_bitrate}" \
@@ -164,41 +203,41 @@ encode_to_target_size () {
 
     do_2pass "${cur_video_bitrate}"
 
-    if [ ! -f "${out_filepath}" ]; then
-      echo "  --> エンコード失敗、ファイルが生成されていません。"
+    if [[ ! -f "${out_filepath}" ]]; then
+      echo "  --> エンコード失敗、ファイルが生成されていません。" >&2
       return 1
     fi
 
     local filesize
     filesize=$(stat -c%s "${out_filepath}" 2>/dev/null)
-    if [ -z "${filesize}" ]; then
-      echo "  --> エンコード失敗、ファイルサイズが取得できません。"
+    if [[ -z "${filesize}" ]]; then
+      echo "  --> エンコード失敗、ファイルサイズが取得できません。" >&2
       return 1
     fi
 
     local diff=$(( filesize - target_max_bytes ))
-    echo "    出力ファイルサイズ: $((filesize/1024/1024)) MB (10MB上限との差分: ${diff} bytes)"
+    echo "    出力ファイルサイズ: $((filesize / 1024 / 1024)) MB (${TARGET_MAX_SIZE_MB}MB上限との差分: ${diff} bytes)"
 
-    if [ "${filesize}" -lt "${target_max_bytes}" ] && [ "${filesize}" -gt "${best_under_size}" ]; then
+    if (( filesize < target_max_bytes && filesize > best_under_size )); then
       best_under_size="${filesize}"
       best_bitrate="${cur_video_bitrate}"
     fi
 
-    if [ "${filesize}" -ge "${target_max_bytes}" ] && [ "${filesize}" -lt "${best_over_size}" ]; then
+    if (( filesize >= target_max_bytes && filesize < best_over_size )); then
       best_over_size="${filesize}"
       best_over_bitrate="${cur_video_bitrate}"
     fi
 
-    if [ "${diff}" -ge 0 ]; then
-      # 10MB以上 → ビットレートを下げる
+    if (( diff >= 0 )); then
+      # 上限以上 → ビットレートを下げる
       max_video_bitrate=$((cur_video_bitrate - 1))
     else
-      # 10MB未満 → 品質を上げるためビットレートを上げる
+      # 上限未満 → 品質を上げるためビットレートを上げる
       min_video_bitrate=$((cur_video_bitrate + 1))
     fi
 
     # 二分探索が収束したら終了
-    if [ "${min_video_bitrate}" -gt "${max_video_bitrate}" ]; then
+    if (( min_video_bitrate > max_video_bitrate )); then
       echo "  --> ビットレート探索範囲が収束しました。"
       break
     fi
@@ -206,8 +245,8 @@ encode_to_target_size () {
     current_loop=$((current_loop + 1))
   done
 
-  if [ "${best_under_size}" -lt 0 ]; then
-    # すべて10MB以上だった場合は、超過が最小の候補を採用
+  if (( best_under_size < 0 )); then
+    # すべて上限以上だった場合は、超過が最小の候補を採用
     best_bitrate="${best_over_bitrate}"
   fi
 
@@ -216,7 +255,6 @@ encode_to_target_size () {
   echo "  --> 最終推奨ビットレート: ${best_bitrate} kbps"
   echo "  --> エンコード完了: ${out_filepath}"
 
-  # 正常終了
   return 0
 }
 
@@ -224,7 +262,7 @@ encode_to_target_size () {
 echo "=== start watching '${INPUT_DIR}' for new .mp4 files ==="
 
 # close_write は「ファイルの書き込みが完了した」というイベント
-inotifywait -m -e close_write --format '%w%f' "${INPUT_DIR}" | while read NEWFILE
+inotifywait -m -e close_write --format '%w%f' "${INPUT_DIR}" | while read -r NEWFILE
 do
   # .mp4 以外はスキップ
   if [[ "${NEWFILE}" =~ \.mp4$ ]]; then
@@ -233,13 +271,12 @@ do
 
     echo
     echo "=== 新しいファイル検知: ${NEWFILE} ==="
-    if [ -f "${OUT_PATH}" ]; then
+    if [[ -f "${OUT_PATH}" ]]; then
       echo "  --> すでに同名のファイルが output/ に存在します。上書きします。"
     fi
 
     # エンコードを実行
-    encode_to_target_size "${NEWFILE}" "${OUT_PATH}"
-    if [ $? -eq 0 ]; then
+    if encode_to_target_size "${NEWFILE}" "${OUT_PATH}"; then
       # 正常終了なら元ファイルを削除
       echo "  --> 元ファイルを削除します: ${NEWFILE}"
       rm -f "${NEWFILE}"


### PR DESCRIPTION
## 概要

出力解像度を720pに変更し、縦動画の自動検出・対応を追加しました。
併せて、スクリプト全体の品質向上のためリファクタリングを実施しています。

## 変更内容

### 🎬 機能変更
- **解像度を720pに変更**: 出力解像度を 1920x1080 (FullHD) から 1280x720 (720p) に変更
- **縦動画の自動対応**: `ffprobe` で入力動画の幅と高さを取得し、縦動画（高さ > 幅）の場合は自動的に 720x1280 でエンコード

### 🔧 リファクタリング
- **`-s` オプションから `-vf scale` フィルターに変更**: `-s` は入力のアスペクト比を無視して強制リサイズするため、`scale` フィルターに置き換え
- **パスログの安全管理**: `mktemp -d` で一時ディレクトリを作成し、パスログの衝突を防止。`trap RETURN` で関数終了時に確実にクリーンアップ
- **`set -euo pipefail` の追加**: エラー検知を強化し、未定義変数の使用を防止
- **条件式の統一**: `[ ]` から `[[ ]]` / `(( ))` に統一し、bash の機能を活用
- **`read -r` の追加**: バックスラッシュの誤解釈を防止
- **エラー出力先の修正**: エラーメッセージを `>&2` で stderr に出力するよう修正
- **`if [ $? -eq 0 ]` の改善**: `if encode_to_target_size ...; then` のイディオムに変更

## テスト方法

1. `input/` に横長の .mp4 ファイルを配置 → 1280x720 で出力されることを確認
2. `input/` に縦長の .mp4 ファイルを配置 → 720x1280 で出力されることを確認
3. 出力ファイルが 10MB 未満であることを確認